### PR TITLE
ci(github-action): update actions/labeler ( v6.0.0 → v6.0.1 )

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -27,7 +27,7 @@ jobs:
           private-key: ${{ secrets.KIREQUE_APP_KEY }}
 
       - name: Labeler
-        uses: actions/labeler@f1a63e87db0c6baf19c5713083f8d00d789ca184 # v6.0.0
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: "${{ steps.app-token.outputs.token }}"
           configuration-path: .github/labeler.yaml


### PR DESCRIPTION
| datasource  | package         | from   | to     |
| ----------- | --------------- | ------ | ------ |
| github-tags | actions/labeler | v6.0.0 | v6.0.1 |